### PR TITLE
Properly skip whitespace when more data is not available (yet)

### DIFF
--- a/parse.lisp
+++ b/parse.lisp
@@ -94,9 +94,9 @@
                (#\r (outc #\Return))
                (#\t (outc #\Tab))
                (#\u (outc (parse-unicode-escape input)))))
-            ((and (or (whitespace-p (peek)) 
-                      (eql (peek) #\:)) 
-                  (not string-quoted)) 
+            ((and (or (whitespace-p (peek))
+                      (eql (peek) #\:))
+                  (not string-quoted))
              (return-from parse-string output))
             (t
              (outc (next)))))))))

--- a/parse.lisp
+++ b/parse.lisp
@@ -105,9 +105,9 @@
   (member char '(#\Space #\Newline #\Tab #\Linefeed #\Return)))
 
 (defun skip-whitespace (input)
-  (loop while (and (listen input)
-                   (whitespace-p (peek-char nil input)))
-        do (read-char input)))
+  (loop for c = (peek-char nil input nil nil)
+     while (and c (whitespace-p c))
+     do (read-char input)))
 
 (defun peek-char-skipping-whitespace (input &optional (eof-error-p t))
   (skip-whitespace input)


### PR DESCRIPTION
This fixes an issue I ran into with `skip-whitespace`, where the use of `listen` caused it to stop skipping early when the server had not sent more data yet (it also removes a bit of trailing whitespace that was floating around -- feel free to discard that commit if you'd rather not have it). The change replaces `listen` with a check for end-of-file, so `peek-char` will block until more data is available if necessary.

Unrelated to this change, I noticed that `peek-char` actually has its own facility for skipping whitespace -- in principle, you might be able to use that directly. It might be better to be explicit about what constitutes whitespace in this context than to reuse CL's definition, though.