### PR TITLE
Fix specializer for null surrogate value.

### DIFF
--- a/encode.lisp
+++ b/encode.lisp
@@ -132,7 +132,7 @@
   (write-string "false" stream)
   object)
 
-(defmethod encode ((object (eql 'null)) &optional (stream *standard-output*))
+(defmethod encode ((object (eql :null)) &optional (stream *standard-output*))
   (write-string "null" stream)
   object)
 


### PR DESCRIPTION
When `yason:*parse-json-null-as-keyword*` is non-`nil`, the result of parsing
`"null"` is a keyword, not a symbol in the yason package, so the encoding
method needs to be specialized on the keyword.